### PR TITLE
Allows external control for Rx Complete loop in sync mode

### DIFF
--- a/src/manuf/sx126x_rf_api.c
+++ b/src/manuf/sx126x_rf_api.c
@@ -566,7 +566,7 @@ RF_API_status_t SX126X_RF_API_receive(RF_API_rx_data_t *rx_data) {
     if ( sx126x_status != SX126X_STATUS_OK)
         EXIT_ERROR((RF_API_status_t) SX126X_RF_API_ERROR_CHIP_RX);
 #ifndef ASYNCHRONOUS
-    while(1) {
+    while(sx126x_ctx.rx_done_flag != 1) {
         if (sx126x_ctx.irq_flag == 1) {
 #ifdef ERROR_CODES
             status = SX126X_RF_API_process();


### PR DESCRIPTION
The STM32 subGHz interrupt handler is already splitting the different IRQ event and clearing the event register. Using the SX126X_RF_API_process function is complex in this situation. But it is simple to rewrite it. As a consequence in synchronous mode, the IRQ handler will work the same way as in async mode and the sync loop here must be able to exit when the Rx has been completed. This will by the  switch of sx126x_cts.rx_done_flag asynchronously. Functionnaly speaking, this modification does not change anything in the current code (rx_done_flag set by SX126X_RF_API_process, so sequentially in synchronous mode) but allows the approach described above.