### PR TITLE
Allows to overide sx126x_get_and_clear_irq_status w/o impacting semtech lib

### DIFF
--- a/src/manuf/sx126x_rf_api.c
+++ b/src/manuf/sx126x_rf_api.c
@@ -167,6 +167,11 @@ errors:
 #endif
 
 /*******************************************************************/
+__attribute__((weak)) sx126x_status_t SX126X_RF_API_get_and_clear_irq_status( const void* context, sx126x_irq_mask_t* irq ) {
+	return sx126x_get_and_clear_irq_status(context,irq);
+}
+
+/*******************************************************************/
 RF_API_status_t SX126X_RF_API_process(void) {
 #ifdef ERROR_CODES
     RF_API_status_t status = RF_API_SUCCESS;
@@ -179,7 +184,7 @@ RF_API_status_t SX126X_RF_API_process(void) {
         EXIT_ERROR((RF_API_status_t) SX126X_RF_API_ERROR_STATE);
     sx126x_ctx.irq_flag = 0;
 
-    sx126x_status = sx126x_get_and_clear_irq_status( SFX_NULL, &sx126x_irq_mask );
+    sx126x_status = SX126X_RF_API_get_and_clear_irq_status( SFX_NULL, &sx126x_irq_mask );
     if (sx126x_status != SX126X_STATUS_OK)
     	EXIT_ERROR((RF_API_status_t) SX126X_RF_API_ERROR_CHIP_IRQ);
     if (sx126x_irq_mask & SX126X_IRQ_TX_DONE) {

--- a/src/manuf/sx126x_rf_api.c
+++ b/src/manuf/sx126x_rf_api.c
@@ -167,11 +167,6 @@ errors:
 #endif
 
 /*******************************************************************/
-__attribute__((weak)) sx126x_status_t SX126X_RF_API_get_and_clear_irq_status( const void* context, sx126x_irq_mask_t* irq ) {
-	return sx126x_get_and_clear_irq_status(context,irq);
-}
-
-/*******************************************************************/
 RF_API_status_t SX126X_RF_API_process(void) {
 #ifdef ERROR_CODES
     RF_API_status_t status = RF_API_SUCCESS;
@@ -184,7 +179,7 @@ RF_API_status_t SX126X_RF_API_process(void) {
         EXIT_ERROR((RF_API_status_t) SX126X_RF_API_ERROR_STATE);
     sx126x_ctx.irq_flag = 0;
 
-    sx126x_status = SX126X_RF_API_get_and_clear_irq_status( SFX_NULL, &sx126x_irq_mask );
+    sx126x_status = (sx126x_status_t) SX126X_RF_API_get_and_clear_irq_status(SIGFOX_NULL, (sfx_u16 *) &sx126x_irq_mask);
     if (sx126x_status != SX126X_STATUS_OK)
     	EXIT_ERROR((RF_API_status_t) SX126X_RF_API_ERROR_CHIP_IRQ);
     if (sx126x_irq_mask & SX126X_IRQ_TX_DONE) {
@@ -846,5 +841,12 @@ void RF_API_error(void) {
     SX126X_RF_API_error();
 }
 #endif
+
+/*** WORKAROUND stm32wlxx_hal_subghz compatibility ***/
+
+/*******************************************************************/
+__attribute__((weak)) sfx_u16 SX126X_RF_API_get_and_clear_irq_status(const void *context, sfx_u16 *irq_mask) {
+    return (sfx_u16) sx126x_get_and_clear_irq_status(context, (sx126x_irq_mask_t *) irq_mask);
+}
 
 #endif /* DYNAMIC_RF_API */


### PR DESCRIPTION
Use of this function is conflicting when using the subghz interrupt handler already defined in stm32wl HAL. For this implementation the process function can't get the values from the register already cleared. The function can be override to match the process expectation. This is a way to limit the impact on the code. (no need to add it in the header file, it would create complexity for nothing)